### PR TITLE
Generates partially applied type aliases for kinds w/ arity > 1

### DIFF
--- a/app/src/main/java/kategory/higherkinds/Option.kt
+++ b/app/src/main/java/kategory/higherkinds/Option.kt
@@ -8,7 +8,7 @@ import kategory.higherkind
 
 @higherkind sealed class StateT<F, S, A> : StateTKind<F, S, A>
 
-typealias X<L> = EitherKindPartiallyApplied<L>
+typealias X<L> = EitherKindPartial<L>
 
-typealias Z<F, S> = StateTKindPartiallyApplied<F, S>
+typealias Z<F, S> = StateTKindPartial<F, S>
 

--- a/app/src/main/java/kategory/higherkinds/Option.kt
+++ b/app/src/main/java/kategory/higherkinds/Option.kt
@@ -5,3 +5,10 @@ import kategory.higherkind
 @higherkind sealed class Option<out A> : OptionKind<A>
 
 @higherkind sealed class Either<L, R> : EitherKind<L, R>
+
+@higherkind sealed class StateT<F, S, A> : StateTKind<F, S, A>
+
+typealias X<L> = EitherKindPartiallyApplied<L>
+
+typealias Z<F, S> = StateTKindPartiallyApplied<F, S>
+

--- a/compile-time/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
+++ b/compile-time/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
@@ -15,6 +15,7 @@ data class HigherKind(
     val tparams: List<ProtoBuf.TypeParameter> = target.classOrPackageProto.typeParameters
     val kindName: Name = target.classElement.simpleName
     val alias: String = if (tparams.size == 1) "kategory.HK" else "kategory.HK${tparams.size}"
+    val typeArgs: List<String> = target.classOrPackageProto.typeParameters.map { target.classOrPackageProto.nameResolver.getString(it.name) }
     val expandedTypeArgs: String = target.classOrPackageProto.typeParameters.joinToString(
             separator = ",", transform = { target.classOrPackageProto.nameResolver.getString(it.name) })
     val name: String = "${kindName}Kind"
@@ -33,21 +34,30 @@ class HigherKindsFileGenerator(
      */
     fun generate() {
         higherKinds.forEachIndexed { counter, hk ->
-            val elementsToGenerate = listOf(genKindMarker(hk), genKindTypeAlias(hk), genEv(hk))
+            val elementsToGenerate = listOf(genKindMarker(hk), genKindTypeAliases(hk), genEv(hk))
             val source: String = elementsToGenerate.joinToString(prefix = "package ${hk.`package`}\n\n", separator = "\n")
             val file = File(generatedDir, higherKindsAnnotationClass.simpleName + "Extensions$counter.kt")
             file.writeText(source)
         }
     }
 
-    private fun genKindTypeAlias(hk: HigherKind): String {
+    private fun genKindTypeAliases(hk: HigherKind): String {
         return if (hk.tparams.isEmpty()) {
             knownError("Class must have at least one type param to derive HigherKinds")
         } else if (hk.tparams.size <= 5) {
-            "typealias ${hk.name}<${hk.expandedTypeArgs}> = ${hk.alias}<${hk.markerName}, ${hk.expandedTypeArgs}>"
+            val kindAlias = "typealias ${hk.name}<${hk.expandedTypeArgs}> = ${hk.alias}<${hk.markerName}, ${hk.expandedTypeArgs}>"
+            val acc = if (hk.tparams.size == 1) kindAlias else kindAlias + "\n" + genPartiallyAppliedKinds(hk)
+            acc
         } else {
             knownError("HigherKinds are currently only supported up to a max of 5 type args")
         }
+    }
+
+    private fun genPartiallyAppliedKinds(hk: HigherKind): String {
+        val appliedTypeArgs = hk.typeArgs.dropLast(1)
+        val expandedAppliedTypeArgs = appliedTypeArgs.joinToString(", ")
+        val hkimpl = if (appliedTypeArgs.size == 1) "kategory.HK" else "kategory.HK${appliedTypeArgs.size}"
+        return "typealias ${hk.name}PartiallyApplied<$expandedAppliedTypeArgs> = $hkimpl<${hk.markerName}, $expandedAppliedTypeArgs>"
     }
 
     private fun genEv(hk: HigherKind): String =

--- a/compile-time/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
+++ b/compile-time/src/main/java/kategory/higherkinds/HigherKindsFileGenerator.kt
@@ -57,7 +57,7 @@ class HigherKindsFileGenerator(
         val appliedTypeArgs = hk.typeArgs.dropLast(1)
         val expandedAppliedTypeArgs = appliedTypeArgs.joinToString(", ")
         val hkimpl = if (appliedTypeArgs.size == 1) "kategory.HK" else "kategory.HK${appliedTypeArgs.size}"
-        return "typealias ${hk.name}PartiallyApplied<$expandedAppliedTypeArgs> = $hkimpl<${hk.markerName}, $expandedAppliedTypeArgs>"
+        return "typealias ${hk.name}Partial<$expandedAppliedTypeArgs> = $hkimpl<${hk.markerName}, $expandedAppliedTypeArgs>"
     }
 
     private fun genEv(hk: HigherKind): String =


### PR DESCRIPTION
Fixes #12 

Given higher kinds with arity > 1, for example:
```kotlin
@higherkind sealed class Either<L, R> : EitherKind<L, R>
@higherkind sealed class StateT<F, S, A> : StateTKind<F, S, A>
```
you get also:
```
typealias EitherKindPartiallyApplied<L> = kategory.HK<EitherHK, L>
typealias StateTKindPartiallyApplied<F, S> = kategory.HK2<StateTHK, F, S>
```
supported up to 5 type args.