### PR TITLE
Generate Kind aliases for @higherkinds compatible with KindedJ 

### DIFF
--- a/annotations/build.gradle
+++ b/annotations/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'kotlin'
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    compile 'com.github.KindedJ:KindedJ:5bee1acf6f'
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/annotations/src/main/java/kategory/hks.kt
+++ b/annotations/src/main/java/kategory/hks.kt
@@ -1,6 +1,6 @@
 package kategory
 
-import io.kindedj.HK as HK_J
+import io.kindedj.HK as HK1_J
 
 interface HK<out F, out A>
 
@@ -12,10 +12,12 @@ typealias HK4<F, A, B, C, D> = HK<HK3<F, A, B, C>, D>
 
 typealias HK5<F, A, B, C, D, E> = HK<HK4<F, A, B, C, D>, E>
 
-typealias HK2_J<F, A, B> = HK_J<HK_J<F, A>, B>
+typealias HK_J<F, A> = HK1_J<F, A>
 
-typealias HK3_J<F, A, B, C> = HK_J<HK2<F, A, B>, C>
+typealias HK2_J<F, A, B> = HK1_J<HK_J<F, A>, B>
 
-typealias HK4_J<F, A, B, C, D> = HK_J<HK3<F, A, B, C>, D>
+typealias HK3_J<F, A, B, C> = HK1_J<HK2<F, A, B>, C>
 
-typealias HK5_J<F, A, B, C, D, E> = HK_J<HK4<F, A, B, C, D>, E>
+typealias HK4_J<F, A, B, C, D> = HK1_J<HK3<F, A, B, C>, D>
+
+typealias HK5_J<F, A, B, C, D, E> = HK1_J<HK4<F, A, B, C, D>, E>

--- a/annotations/src/main/java/kategory/hks.kt
+++ b/annotations/src/main/java/kategory/hks.kt
@@ -1,5 +1,7 @@
 package kategory
 
+import io.kindedj.HK as HK_J
+
 interface HK<out F, out A>
 
 typealias HK2<F, A, B> = HK<HK<F, A>, B>
@@ -9,3 +11,11 @@ typealias HK3<F, A, B, C> = HK<HK2<F, A, B>, C>
 typealias HK4<F, A, B, C, D> = HK<HK3<F, A, B, C>, D>
 
 typealias HK5<F, A, B, C, D, E> = HK<HK4<F, A, B, C, D>, E>
+
+typealias HK2_J<F, A, B> = HK_J<HK_J<F, A>, B>
+
+typealias HK3_J<F, A, B, C> = HK_J<HK2<F, A, B>, C>
+
+typealias HK4_J<F, A, B, C, D> = HK_J<HK3<F, A, B, C>, D>
+
+typealias HK5_J<F, A, B, C, D, E> = HK_J<HK4<F, A, B, C, D>, E>

--- a/app/src/main/java/kategory/higherkinds/Option.kt
+++ b/app/src/main/java/kategory/higherkinds/Option.kt
@@ -4,9 +4,9 @@ import kategory.higherkind
 
 @higherkind sealed class Option<out A> : OptionKind<A>
 
-@higherkind sealed class Either<L, R> : EitherKind<L, R>
+@higherkind sealed class Either<L, R> : EitherKind<L, R>, EitherKindJ<L, R>
 
-@higherkind sealed class StateT<F, S, A> : StateTKind<F, S, A>
+@higherkind sealed class StateT<F, S, A> : StateTKind<F, S, A>, StateTKindJ<F, S, A>
 
 typealias X<L> = EitherKindPartial<L>
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ subprojects { project ->
         jcenter()
         maven { url 'https://kotlin.bintray.com/kotlinx' }
         maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
+        maven { url 'https://jitpack.io' }
     }
 
     apply plugin: 'kotlin'


### PR DESCRIPTION
Right now our direct interop with KindedJ is limited to invariant datatypes. This is caused because our HK is covariant in F and A, whereas KindedJ's isn't at all.

To solve interop we'll provide 2 approaches. For invariant datatypes, this PR will generate a KindedJ typealias. For covariant/contravariant, it'll be required to use Convert as described here: https://github.com/kategory/kategory/pull/216