### PR TITLE
Bump version name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ subprojects { project ->
             repo = 'maven'
             name = POM_ARTIFACT_ID
             userOrg = POM_DEVELOPER_ID
+            licenses = ['Apache-2.0']
+            vcsUrl = 'https://github.com/kategory/kategory-annotations.git'
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Package definitions
 GROUP=io.kategory
-VERSION_NAME=0.3.7-SNAPSHOT
+VERSION_NAME=0.3.8-SNAPSHOT
 
 # Pomfile definitions
 POM_DESCRIPTION=Kategory annotations for easier typed FP


### PR DESCRIPTION
- Bumps version name to `0.3.8-SNAPSHOT`
- Adds Bintray package `licenses` and `vcsUrl` properties (mandatory for OSS packages)

👀 @kategory/maintainers 